### PR TITLE
Makefile cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,33 +1,40 @@
+start:
+	docker-compose up -d
+
+stop:
+	docker-compose stop
+
+logs:
+	docker-compose logs -f
+
 build-backend:
-	docker build -f backend/Dockerfile ./backend -t codeforpoznan/pah-fm-backend
+	docker build ./backend -t codeforpoznan/pah-fm-backend
 
 build-frontend:
-	docker build -f frontend/Dockerfile ./frontend -t codeforpoznan/pah-fm-frontend
+	docker build ./frontend -t codeforpoznan/pah-fm-frontend
 
-# Build project
 build:
 	make build-backend
 	make build-frontend
 
-test-auth:
-	curl -X POST -H "Content-Type: application/json" -d '{"username":"admin","password":"password123"}' http://localhost:8000/api/api-token-auth/
-
-run-django:
-	make manage CMD=runserver
-
-manage:
-	SECRET_KEY=pah-fm DJANGO_SETTINGS_MODULE=pah_fm.settings python3 backend/manage.py ${CMD}
-
-test-backend-docker:
-	docker-compose run --rm backend python3 manage.py test
-
-lint-docker:
-	make lint-frontend-docker
-	make lint-backend-docker
-
-lint-frontend-docker:
-	docker-compose run --rm frontend npm run lint
-
-lint-backend-docker:
+lint-backend:
 	docker-compose run --rm backend pycodestyle --exclude='fleet_management/migrations/*' .
 
+lint-frontend:
+	docker-compose run --rm frontend npm run lint
+
+lint:
+	make lint-frontend
+	make lint-backend
+
+test-backend:
+	docker-compose run --rm backend python3 manage.py test
+
+test:
+	make test-backend
+
+bash-backend:
+	docker-compose exec -ti backend bash
+
+debug-backend:
+	docker attach `docker-compose ps -q backend`

--- a/README.md
+++ b/README.md
@@ -1,29 +1,37 @@
 # pah-fm
 
 
-# Build project
+## Run project (in background)
 
 ```
-make build
+make start
 ```
 
-# Run project
-
+## Stop project
 ```
-docker-compose up
+make stop
 ```
 
-# Run project locally for testing
+## Attach to logs
 ```
-docker-compose up -d db
-
-virtualenv env -p /usr/local/bin/python3
-source env/bin/activate
-
-pip install -r backend/requirements/dev.txt
-
-make manage CMD=createsuperuser
+make logs
 ```
+
+## Run linters
+```
+make lint
+```
+
+## Run tests
+```
+make test
+```
+
+## Debug backend (Django)
+```
+make debug-backend
+```
+After finishing debugging detach from shell using *CTRL*+`p` and *CTRL*+`q`.
 
 ## Initial admin credentials
 We have 2 levels of admin users and 2 initial users - with and without Django Admin access:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,8 @@ services:
     # build: backend
     command: bash docker-entrypoint.sh
     # command: tail -f /dev/null
+    stdin_open: true
+    tty: true
     environment:
       PAH-FM_DB_HOST: db
       PAH-FM_DB_PASS: pah-fm


### PR DESCRIPTION
I removed `-docker` sufix form linting and testing command, as it works perfectly fine inside docker containers and we do not run these command outhide.

Also figure out how to attach to running Django instance. If somebody want to debug Django application, just put `import pdb; pdb.set_trace()` in Django code, and run `make debug-backend`.

To detach You need to press CTRL+`p` and CTRL+`q`.

Will still work on cleaning up nginx setup, but that will be done in separate pull request.