### PR TITLE
Add API docs at /api/docs/.

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,3 +62,7 @@ Links:
 https://pah-backend.herokuapp.com/admin/  - admin
 https://pah-backend.herokuapp.com/api/  - API
 https://pah-fm.firebaseapp.com  - frontend
+
+## API documentation
+Available at `/api/docs/` URL.
+Documentation is available only to logged-in users (DRF quirk).

--- a/backend/pah_fm/settings.py
+++ b/backend/pah_fm/settings.py
@@ -52,6 +52,7 @@ INSTALLED_APPS = [
 
     # 3rd party apps
     'corsheaders',
+    'rest_framework',
 
     # local apps
     'fleet_management',

--- a/backend/pah_fm/urls.py
+++ b/backend/pah_fm/urls.py
@@ -16,6 +16,7 @@ Including another URLconf
 from django.contrib import admin
 from django.urls import path
 
+from rest_framework.documentation import include_docs_urls
 from rest_framework_jwt.views import obtain_jwt_token
 
 from fleet_management.api import (
@@ -30,6 +31,7 @@ from fleet_management.api import (
 
 urlpatterns = [
     path('admin/', admin.site.urls),
+    path('api/docs/', include_docs_urls(title='PAH-FM', public=False)),
     path('api/api-token-auth/', obtain_jwt_token),
     path('api/users/me', CurrentUserRetrieveView.as_view(), name='me'),
     path('api/passengers', PassengerListView.as_view(), name='passengers'),

--- a/backend/requirements/base.txt
+++ b/backend/requirements/base.txt
@@ -1,7 +1,10 @@
+coreapi==2.3.3
 django-cors-headers==2.4.0
 django-filter==2.0.0
 Django==2.1.2
 djangorestframework-camel-case==1.0b1
 djangorestframework-jwt==1.11.0
 djangorestframework==3.8.2
+Markdown==3.0.1
 psycopg2==2.7.5
+Pygments==2.3.1


### PR DESCRIPTION
Adds automatically generated API documentation.

## QA notes

### docs
* Enter `localhost:8080/api/docs/` into browser address bar.
* Verify that API summary is loaded.