### PR TITLE
PAH-149 | add alert after adding a drive

### DIFF
--- a/frontend/src/components/Status.vue
+++ b/frontend/src/components/Status.vue
@@ -11,7 +11,8 @@
 
 <script>
 import { mapState } from 'vuex';
-import { IS_ONLINE, USER } from '../store';
+import { USER } from '../store';
+import { IS_ONLINE } from '../store/constants';
 import { loginRoute } from '../router';
 
 

--- a/frontend/src/store/constants.js
+++ b/frontend/src/store/constants.js
@@ -11,6 +11,8 @@ export const SET_ERRORS = 'setErrors';
 export const SAVE = 'save';
 export const VERIFICATION_TOKEN = 'verificationToken';
 
+export const IS_ONLINE = 'isOnline';
+
 export const namespaces = {
   cars: 'cars',
   drives: 'drives',

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -3,7 +3,7 @@ import Vuex from 'vuex';
 import createPersistedState from 'vuex-persistedstate';
 
 import { actions } from './actions';
-import { VERIFICATION_TOKEN, SYNC, namespaces } from './constants';
+import { VERIFICATION_TOKEN, SYNC, namespaces, IS_ONLINE } from './constants';
 import { mutations, SET_IS_CONNECTED } from './mutations';
 import { modules } from './modules';
 
@@ -15,8 +15,6 @@ export const LANGUAGE = 'language';
 const debug = process.env.NODE_ENV !== 'production';
 
 Vue.use(Vuex);
-
-export const IS_ONLINE = 'isOnline';
 
 const initialState = {
   [USER]: null,
@@ -39,7 +37,7 @@ const store = new Vuex.Store({
     paths: [USER, ROUTES, CARS, LANGUAGE, ...Object.values(namespaces)],
   })],
   getters: {
-    isOnline: state => state.isOnline,
+    [IS_ONLINE]: state => state.isOnline,
   },
 });
 

--- a/frontend/src/store/index.js
+++ b/frontend/src/store/index.js
@@ -18,7 +18,7 @@ Vue.use(Vuex);
 
 export const IS_ONLINE = 'isOnline';
 
-const state = {
+const initialState = {
   [USER]: null,
   [ROUTES]: [],
   [LANGUAGE]: null,
@@ -31,13 +31,16 @@ const state = {
 
 const store = new Vuex.Store({
   strict: debug,
-  state,
+  state: initialState,
   actions,
   modules,
   mutations,
   plugins: [createPersistedState({
     paths: [USER, ROUTES, CARS, LANGUAGE, ...Object.values(namespaces)],
   })],
+  getters: {
+    isOnline: state => state.isOnline,
+  },
 });
 
 window.addEventListener('online', () => {

--- a/frontend/src/translations.json
+++ b/frontend/src/translations.json
@@ -23,7 +23,7 @@
     "routes": {
       "distance_traveled": "Łącznie przejechano {distance} km",
       "passengers": "Pasażerowie:",
-      "passengers-error": "Pasażerowie są wymagani",
+      "passengers_error": "Pasażerowie są wymagani",
       "please_correct_errors": "Please correct the following error(s):",
       "date": "Date:",
       "description": "Description:",
@@ -36,8 +36,8 @@
       "no_driver_routes":
         "Nie masz żadnych tras zapisanych w bazie danych. Możesz dodać nową trasę, wybierając opcję z menu.",
       "from_to": "Z {from} do {destination}",
-      "drive-added-online-notification": "Przejazd został dodany do bazy i oczekuje na potwierdzenie",
-      "drive-added-offline-notification": "Przejazd zostanie dodany do bazy przy ponownym połączeniu z internetem"
+      "drive_added_online_notification": "Przejazd został dodany do bazy i oczekuje na potwierdzenie",
+      "drive_added_offline_notification": "Przejazd zostanie dodany do bazy przy ponownym połączeniu z internetem"
     },
     "login": {
       "user": "Użytkownik: %{username}",
@@ -129,7 +129,7 @@
       "synced_drives": "Previous drives",
       "unsynced_drives": "Unsynces drives",
       "passengers": "Passengers:",
-      "passengers-error": "Passengers are required",
+      "passengers_error": "Passengers are required",
       "please_correct_errors": "Please correct the following error(s):",
       "date": "Date:",
       "description": "Description:",
@@ -142,8 +142,8 @@
       "no_driver_routes":
         "You have no routes stored in database. You can add a new route by choosing option from the menu.",
       "from_to": "From {from} to {destination}",
-      "drive-added-online-notification": "Drive was successfully added to database",
-      "drive-added-offline-notification": "Drive will be added to database after restoring connection to the internet",
+      "drive_added_online_notification": "Drive was successfully added to database",
+      "drive_added_offline_notification": "Drive will be added to database after restoring connection to the internet",
       "cars": "Choose a car:",
       "car": "With car:",
       "fetching_cars_error": "Fetching cars unsuccessful",

--- a/frontend/src/translations.json
+++ b/frontend/src/translations.json
@@ -35,7 +35,9 @@
       "validation_error": "{field} is required",
       "no_driver_routes":
         "Nie masz żadnych tras zapisanych w bazie danych. Możesz dodać nową trasę, wybierając opcję z menu.",
-      "from_to": "Z {from} do {destination}"
+      "from_to": "Z {from} do {destination}",
+      "drive-added-online-notification": "Przejazd został dodany do bazy i oczekuje na potwierdzenie",
+      "drive-added-offline-notification": "Przejazd zostanie dodany do bazy przy ponownym połączeniu z internetem"
     },
     "login": {
       "user": "Użytkownik: %{username}",
@@ -140,6 +142,8 @@
       "no_driver_routes":
         "You have no routes stored in database. You can add a new route by choosing option from the menu.",
       "from_to": "From {from} to {destination}",
+      "drive-added-online-notification": "Drive was successfully added to database",
+      "drive-added-offline-notification": "Drive will be added to database after restoring connection to the internet",
       "cars": "Choose a car:",
       "car": "With car:",
       "fetching_cars_error": "Fetching cars unsuccessful",

--- a/frontend/src/views/RouteFormView.vue
+++ b/frontend/src/views/RouteFormView.vue
@@ -4,6 +4,22 @@
       <div class="row">
         <div class="col-lg-8 offset-lg-2">
           <div>
+            <b-alert
+              variant="success"
+              dismissible
+              :show="confirmationOnline"
+              @dismissed="confirmationOnline=false"
+            >
+              <b>{{ $t('routes.drive-added-online-notification') }}</b>
+            </b-alert>
+            <b-alert
+              variant="secondary"
+              dismissible
+              :show="confirmationOffline"
+              @dismissed="confirmationffline=false"
+            >
+              <b>{{ $t('routes.drive-added-offline-notification') }}</b>
+            </b-alert>
             <div
               class="alert alert-danger errors"
               v-if="Object.keys(errors).length">
@@ -135,7 +151,7 @@
 <script>
 import { MultiSelect } from 'vue-search-select';
 
-import { mapActions, mapState } from 'vuex';
+import { mapActions, mapGetters, mapState } from 'vuex';
 import * as actions from '../store/actions';
 import { isErroring, makeErrors, stringFields } from './services';
 import { namespaces, actions as apiActions } from '../store/constants';
@@ -163,6 +179,8 @@ export default {
       searchText: '',
       selectedPassengers: [],
       lastSelectPassenger: {},
+      confirmationOnline: false,
+      confirmationOffline: false,
     };
   },
   methods: {
@@ -176,11 +194,18 @@ export default {
     },
     handleSubmit() {
       this.validateForm();
+      this.confirmationOffline = false;
+      this.confirmationOnline = false;
 
       if (!Object.keys(this.errors).length) {
         this[actions.SUBMIT]({ form: { ...this.route, syncId: Math.floor(Date.now() / 1000) } });
         this.route = { ...defaultFormState };
         this.selectedPassengers = [];
+        if (this.isOnline) {
+          this.confirmationOnline = true;
+        } else {
+          this.confirmationOffline = true;
+        }
       }
     },
 
@@ -230,6 +255,7 @@ export default {
         text: [p.firstName, p.lastName].join(' '),
       })),
     }),
+    ...mapGetters(['isOnline']),
     distance() {
       const distance = this.route.endMileage - this.route.startMileage;
       return distance > 0 ? distance : 0;

--- a/frontend/src/views/RouteFormView.vue
+++ b/frontend/src/views/RouteFormView.vue
@@ -10,7 +10,7 @@
               :show="confirmationOnline"
               @dismissed="confirmationOnline=false"
             >
-              <b>{{ $t('routes.drive-added-online-notification') }}</b>
+              <b>{{ $t('routes.drive_added_online_notification') }}</b>
             </b-alert>
             <b-alert
               variant="secondary"
@@ -18,7 +18,7 @@
               :show="confirmationOffline"
               @dismissed="confirmationffline=false"
             >
-              <b>{{ $t('routes.drive-added-offline-notification') }}</b>
+              <b>{{ $t('routes.drive_added_offline_notification') }}</b>
             </b-alert>
             <div
               class="alert alert-danger errors"
@@ -154,7 +154,7 @@ import { MultiSelect } from 'vue-search-select';
 import { mapActions, mapGetters, mapState } from 'vuex';
 import * as actions from '../store/actions';
 import { isErroring, makeErrors, stringFields } from './services';
-import { namespaces, actions as apiActions } from '../store/constants';
+import { namespaces, actions as apiActions, IS_ONLINE } from '../store/constants';
 
 const defaultFormState = {
   date: '',
@@ -226,7 +226,7 @@ export default {
         .reduce(makeErrorsPartial, {});
 
       if (!data.passengers || !data.passengers.length) {
-        this.errors.passengers = this.$t('routes.passengers-error');
+        this.errors.passengers = this.$t('routes.passengers_error');
       }
 
       const { startMileage, endMileage } = data;
@@ -255,7 +255,7 @@ export default {
         text: [p.firstName, p.lastName].join(' '),
       })),
     }),
-    ...mapGetters(['isOnline']),
+    ...mapGetters([IS_ONLINE]),
     distance() {
       const distance = this.route.endMileage - this.route.startMileage;
       return distance > 0 ? distance : 0;


### PR DESCRIPTION
Resolves #149 

### QA notes

After adding a drive:
* if app is online - green alert is shown, confirming that drive was added to database
* if app in offline - grey alert is shown, informing that drive will be added to database, whem app will be online again

Alerts are dissmisable, clicking 'x' button on alert should close it.
Only one alert should be visible at a time.

