### PR TITLE
[250] Merge driver first and last_name to single column in admin export

### DIFF
--- a/backend/fleet_management/admin.py
+++ b/backend/fleet_management/admin.py
@@ -7,6 +7,10 @@ from .models import Car, Passenger, Drive, User, Project, VerificationToken
 
 
 class DriveResource(resources.ModelResource):
+
+    def dehydrate_driver(self, drive):
+        return f"{drive.driver.first_name} {drive.driver.last_name}"
+
     def dehydrate_passengers(self, drive):
         return "/".join("{} {}".format(
             p.first_name, p.last_name) for p in drive.passengers.all()
@@ -16,8 +20,7 @@ class DriveResource(resources.ModelResource):
         model = Drive
         fields = (
             "id",
-            "driver__first_name",
-            "driver__last_name",
+            "driver",
             "car__plates",
             "passengers",
             "date",


### PR DESCRIPTION
Issue: https://github.com/CodeForPoznan/pah-fm/issues/250
Follow-up to: https://github.com/CodeForPoznan/pah-fm/pull/267
In reference to: https://github.com/CodeForPoznan/pah-fm/issues/250#issuecomment-511231067

Instead of exporting drivers' first and second name as separate columns, export them in single column named `driver`.