### PR TITLE
Ignore static files in backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@ env
 venv/
 chromedriver
 
-backend/emails
+backend/emails/
+backend/static/
 
 *.retry


### PR DESCRIPTION
Thought it might be useful, I often see `/backend/static` in `git status`.