### PR TITLE
Fixing Travis after_success bash if-statement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ script:
 after_success:
   - if [ "$TRAVIS_REPO_SLUG" == "codeforpoznan/pah-fm" ] && \
        [ "$TRAVIS_BRANCH" == "develop" ] && \
-       [ "$TRAVIS_PULL_REQUEST" = false ]
+       [ "$TRAVIS_PULL_REQUEST" == "false" ];
     then
       docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD;
       cd backend;


### PR DESCRIPTION
Before that we were getting:
```
0.00s$ if [ "$TRAVIS_REPO_SLUG" == "codeforpoznan/pah-fm" ] && \ [ "$TRAVIS_BRANCH" == "develop" ] && \ [ "$TRAVIS_PULL_REQUEST" = false ] then docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD; cd backend; docker build -f Dockerfile -t codeforpoznan/pah-fm-backend:latest .; docker push codeforpoznan/pah-fm-backend; cd ../frontend; docker build -f Dockerfile -t codeforpoznan/pah-fm-frontend:latest .; docker push codeforpoznan/pah-fm-frontend; cd ..; fi
/home/travis/.travis/functions: eval: line 104: syntax error near unexpected token `fi'
/home/travis/.travis/functions: eval: line 104: `if [ "$TRAVIS_REPO_SLUG" == "codeforpoznan/pah-fm" ] && \ [ "$TRAVIS_BRANCH" == "develop" ] && \ [ "$TRAVIS_PULL_REQUEST" = false ] then docker login -u $DOCKER_USERNAME -p $DOCKER_PASSWORD; cd backend; docker build -f Dockerfile -t codeforpoznan/pah-fm-backend:latest .; docker push codeforpoznan/pah-fm-backend; cd ../frontend; docker build -f Dockerfile -t codeforpoznan/pah-fm-frontend:latest .; docker push codeforpoznan/pah-fm-frontend; cd ..; fi '
```