### PR TITLE
[226] Skip repo cleanup on build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ cache:
 
 env:
   global:
-    - SECRET_KEY="TRAVIS-SECRET-KEY"
+    - SECRET_KEY=TRAVIS-SECRET-KEY
     - secure: "FvksvizyP/p/ZmMD+Dq5STciE5EXAtPFMG4GI84QbQ7jcAFyIqSqxHAfhBpC4mW0Mu3Tv8Iz8/K24bcAL3AwKINKD3L+G7qing+y+/5XzGNudLMFNt9Ag+bm3o3KkbSVSGmH1zWccuE2SpFwFYT7MpBsvXIoYyeuesPpoUtr0SopYvBKXPOCxqNrC27tVWsND1AyM7T0+xmLye4S6s4cuDcIuzUw9XhIUK4tZdEPZkKODwjQ8aAIOHDWs0B8xiqe7+z4UlW6wewsVk9ZV5ij7RVuBcBUmLJn/RaT87TZ1fRE/s7eNP8sQGfFuU1gTYMw7Nj+/8kA8JjSegxhudaxZAVH6kQ321mEPGVhoZOhLV5/shBXYT39eI2vXtYigmXRz6RLZSvKjA/ZKRuYRxrg4KvdL1sdxcHgrznZN4UxkwdL4RZYUOgb0Hko/3ZLS4qOcPlEEF1LtZa3gqhmmgUQP0Z9qdVSemQYt2K9QFMF75Yy5mx/rRnEwVBOrlIsKZmULphOVakMSKzLlhatx28dFyO7wpMBbt2yzAX3Uw1UVzoI3v2WcDmdXjYwTSaCkpU8iBx5TA7NvkGG538L35ZI/TH04Osu33JYg/hIyVE/GjiD4vEmJo6Qcr/1pSE38stGVNDTqN6beOUUIgAQ9mBV4vDXwWvE8oVUE9I4qJYWKWU="
 
 
@@ -40,6 +40,7 @@ script:
 deploy:
   provider: script
   script: bash deploy.sh
+  skip_cleanup: true
   on:
     repo: CodeForPoznan/pah-fm
     branch: master


### PR DESCRIPTION
Same problem as in cfp v3: https://github.com/CodeForPoznan/codeforpoznan.pl_v3/commit/7a357e2f97f27bbd2c8ea29cc8a71627c924c5c2
```
> pah-fm@0.1.0 build /home/travis/build/CodeForPoznan/pah-fm/frontend

> vue-cli-service build

sh: 1: vue-cli-service: not found
```
https://travis-ci.com/github/CodeForPoznan/pah-fm/builds/172897518 line 1730