### PR TITLE
[406] Fix edge case in test_search_*

### DIFF
--- a/backend/fleet_management/tests/test_cars.py
+++ b/backend/fleet_management/tests/test_cars.py
@@ -26,14 +26,15 @@ class CarsApiTestCase(APITestCase):
         res = self.client.get(self.url)
         self.assertEqual(res.status_code, status.HTTP_200_OK)
         self.assertEqual(len(self.cars), len(res.data))
-        for idx, car in enumerate(sorted(res.data, key=lambda car: car["id"])):
+        for idx, car in enumerate(sorted(res.data, key=lambda c: c["id"])):
             self.assertEqual(car["plates"], self.cars[idx].plates)
 
     def test_search_by_plate(self):
         self.client.force_login(self.user)
-        url_params = urlencode({"search": self.cars[0].plates})
+        searched_car = self.cars[0]
+        url_params = urlencode({"search": searched_car.plates})
         res = self.client.get(f"{self.url}?{url_params}")
-        cars = res.data
         self.assertEqual(res.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(cars), 1)
-        self.assertEqual(cars[0]["id"], self.cars[0].id)
+        returned_ids = map(lambda c: c["id"], res.data)
+        self.assertIn(searched_car.id, returned_ids)
+        self.assertTrue(len(res.data))

--- a/backend/fleet_management/tests/test_passengers.py
+++ b/backend/fleet_management/tests/test_passengers.py
@@ -41,8 +41,10 @@ class PassengersApiTestCase(APITestCase):
 
     def test_search_passengers_by_first_name(self):
         self.client.force_login(self.user)
-        url_params = urlencode({"search": self.passengers[0].first_name})
+        searched_passenger = self.passengers[0]
+        url_params = urlencode({"search": searched_passenger.first_name})
         res = self.client.get(f"{self.url}?{url_params}")
         self.assertEqual(res.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(res.data), 1)
-        self.assertEqual(res.data[0]["id"], self.passengers[0].id)
+        returned_ids = map(lambda p: p["id"], res.data)
+        self.assertIn(searched_passenger.id, returned_ids)
+        self.assertTrue(len(res.data))


### PR DESCRIPTION
So, this happened: https://github.com/CodeForPoznan/pah-fm/pull/497/files#r448654206 on recent build on master branch, which forced me to rethink the approach to `test_search_` methods :)

This time it will not fail! 