### PR TITLE
Use set_password() when creating user in factory

### DIFF
--- a/backend/fleet_management/factories.py
+++ b/backend/fleet_management/factories.py
@@ -4,7 +4,6 @@ from datetime import timedelta
 import random
 
 from django.utils.timezone import now
-from django.contrib.auth.hashers import make_password
 from factory import (
     fuzzy,
     DjangoModelFactory,
@@ -39,7 +38,7 @@ class UserFactory(DjangoModelFactory):
     def _create(cls, model_class, *args, **kwargs):
         groups = kwargs.pop("groups", [])
         user = super()._create(model_class, *args, **kwargs)
-        user.password = make_password(user.password)
+        user.set_password(cls.password)
         for g in groups:
             user.groups.add(g)
         user.save()


### PR DESCRIPTION
Trivial fix for situation when developer runs multiple times `make populate-database`.
Instead of relying on the previous password (which will be encrypted the second time someone runs this command) use the password defined in factory class because it stays constant.