### PR TITLE
display error message on login screen

### DIFF
--- a/frontend/src/store/actions.js
+++ b/frontend/src/store/actions.js
@@ -40,15 +40,19 @@ export const actions = {
 
   async [LOGIN]({ commit, dispatch }, credentials) {
     commit(mutations.SET_LOGIN_PROGRESS, true);
+    commit(mutations.SET_LOGIN_ERROR, null);
     try {
       await dispatch(`http/${HTTP_LOGIN}`, credentials);
-      commit(mutations.SET_LOGIN_ERROR, null);
       dispatch(FETCH_USER, {
         callback: () => window.location.replace('/drive'),
       });
     } catch (err) {
       console.error(err);
-      commit(mutations.SET_LOGIN_ERROR, i18n.tc('login.login_error'));
+      const { response: {
+        status,
+      } } = err;
+
+      commit(mutations.SET_LOGIN_ERROR, status === 403 ? i18n.tc('login.login_group_error') : i18n.tc('login.login_error'));
     } finally {
       commit(mutations.SET_LOGIN_PROGRESS, false);
     }

--- a/frontend/src/translations.json
+++ b/frontend/src/translations.json
@@ -273,6 +273,7 @@
     },
     "login": {
       "login_error": "Login unsuccessful",
+      "login_group_error": "You are not allowed to log in because this account does not exist or you do not belong to any group. If you want to log in, ask the admin to add you to the group of Passengers or Drivers.",
       "password": "Password",
       "password_required": "Password is required",
       "user": "User: %{username}",
@@ -372,6 +373,8 @@
       "verified_drive": "Ten przejazd został zweryfikowany."
     },
     "login": {
+      "login_error": "Logowanie nie powiodło się",
+      "login_group_error": "Nie możesz się zalogować ponieważ konto nie istnieje lub nie należysz do żadnej grupy. Poproś administratora o dodanie do grupy Kierowców lub Pasażerów.",
       "password": "Hasło",
       "password_required": "Hasło jest wymagane",
       "user": "Użytkownik: %{username}",

--- a/frontend/src/views/LoginView.vue
+++ b/frontend/src/views/LoginView.vue
@@ -4,12 +4,13 @@
       <div class="container">
         <div class="row">
           <div class="col-md-12">
-            <div
-              v-if="loginError"
-              class="alert alert-danger"
+            <b-alert
+              variant="danger"
+              dismissible
+              :show="!!loginError"
             >
               {{ loginError }}
-            </div>
+            </b-alert>
             <h2>{{ $t('common.login') }}</h2>
             <form @submit.prevent="handleSubmit">
               <div class="form-group">


### PR DESCRIPTION
403 status is sent by backend when the user does not exist or when the user doesn't belong to any group. In this case, different login error is displayed. I've also changed the alert to dismissable. 